### PR TITLE
Add second staging model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dbt-env/
+logs/

--- a/dbt_payment_data/models/staging/schema.yml
+++ b/dbt_payment_data/models/staging/schema.yml
@@ -22,3 +22,22 @@ models:
       - name: chargeback_status
       - name: chargeback_source
       - name: is_chargeback
+
+  - name: stg_transactions
+    description: "Transactions from Globalpay API"
+    columns:
+      - name: transaction_id
+        description: "The primary key for this table"
+        data_tests:
+          - unique
+          - not_null
+      - name: chargeback_id
+      - name: transaction_country
+      - name: transaction_currency
+      - name: exchange_rates
+      - name: transaction_status
+      - name: transaction_source
+      - name: transaction_state
+      - name: transaction_amount
+      - name: is_cvv_provided
+      - name: transaction_date

--- a/dbt_payment_data/models/staging/stg_transactions.sql
+++ b/dbt_payment_data/models/staging/stg_transactions.sql
@@ -1,0 +1,26 @@
+{{ config(materialized='table') }}
+
+with transactions as (
+
+    select 
+    ref as transaction_id
+    ,external_ref as chargeback_id
+
+    ,country as transaction_country
+    ,currency as transaction_currency
+    ,rates as exchange_rates
+
+    ,status as transaction_status
+    ,source as transaction_source
+    ,state as transaction_state
+
+    ,amount as transaction_amount
+    ,cvv_provided as is_cvv_provided
+    ,date_time as transaction_date
+
+    from {{ source('global_pay', 'acceptance_report') }}
+
+)
+
+select *
+from transactions


### PR DESCRIPTION
**Background:**
- raw models need to be added to dbt as staging tables

**Aim:**
- clean data from `global_pay.acceptance_report`
- rename model to `stg_transactions`

**Testing:**

- accessed `stg_transactions` model in BigQuery
- same number of rows:
```
select count(*) from `global_pay.stg_transactions`
union all 
select count(*) from `global_pay.acceptance_report`
```