### PR TITLE
add int_transactions

### DIFF
--- a/dbt_payment_data/models/intermediate/int_transactions.sql
+++ b/dbt_payment_data/models/intermediate/int_transactions.sql
@@ -1,0 +1,81 @@
+{% set currencies = dbt_utils.get_column_values(table=ref('stg_transactions'), column='transaction_currency') %}
+
+with
+
+transactions as (
+
+        select * from {{ref('stg_transactions')}}
+
+),
+
+extract_rates as (
+
+    select
+
+        transaction_id
+        ,chargeback_id
+
+        ,transaction_country
+        ,transaction_currency
+        ,exchange_rates
+
+        ,transaction_status
+        ,transaction_source
+        ,transaction_state
+
+        ,transaction_amount
+        ,is_cvv_provided
+        ,transaction_date
+        {% for currency in currencies %}
+        ,case 
+            when transaction_currency = '{{currency}}' then cast(json_extract(exchange_rates, '$.{{currency}}')as float64)
+            else null
+        end as {{currency}}_rate
+        {% endfor %}
+                
+    from transactions
+),
+
+final as (
+    
+    select
+
+        transaction_id
+        ,chargeback_id
+
+        ,transaction_country
+        ,transaction_currency
+        ,exchange_rate
+
+        ,transaction_status
+        ,transaction_source
+        ,transaction_state
+
+        ,transaction_amount as original_currency_amount
+        ,case
+            when transaction_currency = 'USD' then transaction_amount
+            else transaction_amount / exchange_rate
+        end as usd_amount
+        ,is_cvv_provided
+        ,transaction_date
+
+    from extract_rates
+
+    unpivot (
+
+        exchange_rate for rate in (
+
+            {% for currency in currencies %}
+                {{currency}}_rate
+                {% if not loop.last %}
+                ,
+                {% endif %}
+            {% endfor %}
+
+        )
+    )
+
+)
+
+select * from final
+

--- a/dbt_payment_data/package-lock.yml
+++ b/dbt_payment_data/package-lock.yml
@@ -1,0 +1,4 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0
+sha1_hash: 226ae69cdfbc9367e2aa2c472b01f99dbce11de0

--- a/dbt_payment_data/packages.yml
+++ b/dbt_payment_data/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0


### PR DESCRIPTION
****Background:****
- exchange rate must be extracted to convert non usd currencies 

**Aim:**
- convert all non usd currencies to usd 

**Transformations:**
- create jinja function to dynamically extract exchange rate from json
- apply exchange rate to each non usd transaction

**Testing:**

all of the following queries should output 0 to show there is no difference between the extracted exchange rate and the rate in the json field:
```
SELECT count(*)
FROM `data-modeling-challenge.globepay.int_transactions` 
where transaction_currency = 'USD'
and exchange_rate != 1

select count(*)
from `data-modeling-challenge.globepay.int_transactions` int 
inner join `data-modeling-challenge.globepay.int_transactions` stg
on int.transaction_id = stg.transaction_id
where int.transaction_currency = 'CAD'
and int.exchange_rate != cast(json_extract(stg.exchange_rates, '$.CAD') as float64)

select count(*)
from `data-modeling-challenge.globepay.int_transactions` int 
inner join `data-modeling-challenge.globepay.int_transactions` stg
on int.transaction_id = stg.transaction_id
where int.transaction_currency = 'EUR'
and int.exchange_rate != cast(json_extract(stg.exchange_rates, '$.EUR') as float64)

select count(*)
from `data-modeling-challenge.globepay.int_transactions` int 
inner join `data-modeling-challenge.globepay.int_transactions` stg
on int.transaction_id = stg.transaction_id
where int.transaction_currency = 'MXN'
and int.exchange_rate != cast(json_extract(stg.exchange_rates, '$.MXN') as float64)

select count(*)
from `data-modeling-challenge.globepay.int_transactions` int 
inner join `data-modeling-challenge.globepay.int_transactions` stg
on int.transaction_id = stg.transaction_id
where int.transaction_currency = 'GBP'
and int.exchange_rate != cast(json_extract(stg.exchange_rates, '$.GBP') as float64)
```

